### PR TITLE
Ajout paramétrage de mistral et affichage réponse en mode streaming

### DIFF
--- a/config/secrets.json
+++ b/config/secrets.json
@@ -3,6 +3,9 @@
 	"use_memory_for_data": true,
 	"model_name": "mistral:latest",
 	"log_execution_times": true,
+	"context_length": 8192,
+	"embedding_length": 1024,
+	"stream": true,
 	 "prompt_instructions": [
         "Instructions:",
 		"0. La langue utilisée pour les échanges et la langue du contexte est le français",

--- a/cv_app/views.py
+++ b/cv_app/views.py
@@ -4,6 +4,7 @@ from django.views.decorators.http import require_http_methods
 from django.views.decorators.csrf import csrf_protect
 from django.views.decorators.csrf import requires_csrf_token, ensure_csrf_cookie
 from django.conf import settings
+from django.http import StreamingHttpResponse, HttpResponseNotAllowed
 import json
 from ollama_client.client import get_ollama_response
 
@@ -15,19 +16,21 @@ def index_view(request):
 def cv_view(request):
     return render(request, 'cv_app/cv.html')
 @csrf_protect
-@require_http_methods(["POST"])
 @requires_csrf_token
 @ensure_csrf_cookie
 def chatbot(request):
-    if request.method == 'POST':
-        data = json.loads(request.body)
-        question = data.get('question')
-        session_id = data.get('session_id')
+    if request.method == 'GET':
+        question = request.GET.get('question')
+        session_id = request.GET.get('session_id')
 
-        answer = get_ollama_response(question)
+        def generate_response():
+            for chunk in get_ollama_response(question):
+                yield f"data: {json.dumps({'chunk': chunk})}\n\n"
+            yield f"event: close\ndata: {json.dumps({'session_id': session_id})}\n\n"
 
-        return JsonResponse({'answer': answer, 'session_id': session_id})
-
+        return StreamingHttpResponse(generate_response(), content_type='text/event-stream')
+    else:
+        return HttpResponseNotAllowed(['GET'])
 def get_initial_message(request):
     with open(SECRETS_FILE, 'r') as f:
         secrets = json.load(f)

--- a/ollama_client/client.py
+++ b/ollama_client/client.py
@@ -143,6 +143,7 @@ def search_relevant_docs(query, top_k=3):
 
 @log_execution_time
 def get_ollama_response(question):
+    start_time = time.time()  # Début du chronométrage
     OLLAMA_URL = os.environ.get('OLLAMA_URL')
     SALAD_API_KEY = os.environ.get('SALAD_API_KEY')
 
@@ -207,6 +208,9 @@ def get_ollama_response(question):
                             yield chunk
                     except json.JSONDecodeError:
                         logger.error(f"Erreur de décodage JSON: {line}")
+            end_time = time.time()  # Fin du chronométrage
+            execution_time = end_time - start_time
+            logger.info(f"Temps d'exécution de get_ollama_response: {execution_time:.4f} secondes")
             save_interaction(question, full_response)
         else:
             error_message = f"Erreur: {response.status_code} - {response.text}"


### PR DESCRIPTION
Ajout de paramétrage de l'appel à Mistral afin d'augmenter la rapidité de la génération de la réponse. Les paramètres sont stockés dans secrets.json.
De plus affichage de la réponse en mode streaming, c'est-à-dire par affichage des chunks